### PR TITLE
Add Nicolas Wu & Tom Schrijvers to authors & copyrights

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018, Rob Rix and Patrick Thomson
+Copyright (c) 2018, Nicolas Wu, Tom Schrijvers, Rob Rix, and Patrick Thomson
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -5,7 +5,7 @@ description:         A fast, flexible, fused effect system, à la Effect Handler
 homepage:            https://github.com/robrix/fused-effects
 license:             BSD3
 license-file:        LICENSE
-author:              Rob Rix, Patrick Thomson
+author:              Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
 maintainer:          robrix@github.com
 copyright:           2018 Rob Rix, Patrick Thomson
 category:            Control

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -7,7 +7,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
 maintainer:          robrix@github.com
-copyright:           2018 Rob Rix, Patrick Thomson
+copyright:           2018 Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
 category:            Control
 build-type:          Simple
 extra-source-files:


### PR DESCRIPTION
Nicolas Wu’s & Tom Schrijvers’ work was monumentally important for this development; aside from a few things being renamed, a slight tweak to the shape of effect functors to integrate _Effect Handlers in Scope_ with _Fusion for Free_, and one or two new effects, this work was derived directly from their papers. Therefore, I’m adding them to the LICENSE and `authors` field.