### PR TITLE
Cut complexity

### DIFF
--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -81,9 +81,6 @@ branch _ _ _ f (Alt a b) = f a b
 runBranch :: Alternative m => Branch m a -> m a
 runBranch = branch empty empty pure (<|>)
 
-bindBranch :: (Alternative m, Carrier sig m, Monad m) => m (Branch m a) -> (b -> m (Branch m a)) -> Branch m b -> m (Branch m a)
-bindBranch cut bind = branch cut (ret None) bind (\ a b -> ret (Alt (a >>= bind >>= runBranch) (b >>= bind >>= runBranch)))
-
 
 -- | Run a 'Cut' effect within an underlying 'Alternative' instance (typically 'Eff' carrying a 'NonDet' effect).
 --
@@ -103,6 +100,8 @@ instance (Alternative m, Carrier sig m, Effect sig, Monad m) => Carrier (Cut :+:
     (\case
       Cutfail  -> ret Cut
       Call m k -> runCutC m >>= bindBranch (ret None) (runCutC . k))
+    where bindBranch :: (Alternative m, Carrier sig m, Monad m) => m (Branch m a) -> (b -> m (Branch m a)) -> Branch m b -> m (Branch m a)
+          bindBranch cut bind = branch cut (ret None) bind (\ a b -> ret (Alt (a >>= bind >>= runBranch) (b >>= bind >>= runBranch)))
 
 
 -- $setup

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -6,6 +6,7 @@ module Control.Effect.Cut
 , cut
 , Branch(..)
 , branch
+, runBranch
 , runCut
 , CutC(..)
 ) where
@@ -71,6 +72,9 @@ branch :: a -> a -> (b -> a) -> Branch b -> a
 branch a _ _ Cut      = a
 branch _ a _ None     = a
 branch _ _ f (Pure a) = f a
+
+runBranch :: Alternative m => Branch a -> m a
+runBranch = branch empty empty pure
 
 
 -- | Run a 'Cut' effect within an underlying 'Alternative' instance (typically 'Eff' carrying a 'NonDet' effect).

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -61,17 +61,6 @@ data Branch a
   | Pure a
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
-instance Applicative Branch where
-  pure = Pure
-  {-# INLINE pure #-}
-
-  Cut    <*> _      = Cut
-  _      <*> Cut    = Cut
-  None   <*> _      = None
-  _      <*> None   = None
-  Pure f <*> Pure a = Pure (f a)
-  {-# INLINE (<*>) #-}
-
 -- | Case analysis for 'Branch', taking a value to use for 'Cut', a value to use for 'None', and a function to apply to the contents of 'Pure'.
 --
 --   prop> branch Cut None Pure a == a

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -61,6 +61,15 @@ data Branch a
   | Some a
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
+instance Applicative Branch where
+  pure = Some
+
+  Prune  <*> _      = Prune
+  _      <*> Prune  = Prune
+  None   <*> _      = None
+  _      <*> None   = None
+  Some f <*> Some a = Some (f a)
+
 -- | Case analysis for 'Branch', taking a value to use for 'Prune', a value to use for 'None', and a function to apply to the contents of 'Some'.
 --
 --   prop> branch Prune None Some a == a

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -63,19 +63,23 @@ data Branch a
 
 instance Applicative Branch where
   pure = Some
+  {-# INLINE pure #-}
 
   Prune  <*> _      = Prune
   _      <*> Prune  = Prune
   None   <*> _      = None
   _      <*> None   = None
   Some f <*> Some a = Some (f a)
+  {-# INLINE (<*>) #-}
 
 instance Monad Branch where
   return = pure
+  {-# INLINE return #-}
 
   Prune  >>= _ = Prune
   None   >>= _ = None
   Some a >>= f = f a
+  {-# INLINE (>>=) #-}
 
 -- | Case analysis for 'Branch', taking a value to use for 'Prune', a value to use for 'None', and a function to apply to the contents of 'Some'.
 --

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -49,7 +49,8 @@ call m = send (Call m ret)
 
 -- | Commit to the current branch, preventing backtracking within the nearest enclosing 'call' (if any) on failure.
 --
---   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) == [a, b]
+--   prop> run (runNonDet (runCut (pure a <|> cut *> pure b))) == [a, b]
+--   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) == [a]
 --   prop> run (runNonDet (runCut (cut *> empty <|> pure a))) == []
 cut :: (Alternative m, Carrier sig m, Member Cut sig) => m ()
 cut = pure () <|> cutfail

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -70,6 +70,13 @@ instance Applicative Branch where
   _      <*> None   = None
   Some f <*> Some a = Some (f a)
 
+instance Monad Branch where
+  return = pure
+
+  Prune  >>= _ = Prune
+  None   >>= _ = None
+  Some a >>= f = f a
+
 -- | Case analysis for 'Branch', taking a value to use for 'Prune', a value to use for 'None', and a function to apply to the contents of 'Some'.
 --
 --   prop> branch Prune None Some a == a

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -81,7 +81,7 @@ runBranch = branch empty empty pure
 --
 --   prop> run (runNonDetOnce (runCut (pure a))) == Just a
 runCut :: (Alternative m, Carrier sig m, Effect sig, Monad m) => Eff (CutC m) a -> m a
-runCut = (>>= branch empty empty pure) . runCutC . interpret
+runCut = (>>= runBranch) . runCutC . interpret
 
 newtype CutC m a = CutC { runCutC :: m (Branch a) }
 

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -72,15 +72,6 @@ instance Applicative Branch where
   Pure f <*> Pure a = Pure (f a)
   {-# INLINE (<*>) #-}
 
-instance Monad Branch where
-  return = pure
-  {-# INLINE return #-}
-
-  Cut    >>= _ = Cut
-  None   >>= _ = None
-  Pure a >>= f = f a
-  {-# INLINE (>>=) #-}
-
 -- | Case analysis for 'Branch', taking a value to use for 'Cut', a value to use for 'None', and a function to apply to the contents of 'Pure'.
 --
 --   prop> branch Cut None Pure a == a

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -15,6 +15,7 @@ import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.NonDet
 import Control.Effect.Sum
+import Data.Monoid (Alt(..))
 
 -- | 'Cut' effects are used with 'NonDet' to provide control over backtracking.
 data Cut m k
@@ -118,3 +119,50 @@ instance (Alternative m, Carrier sig m, Effect sig, Monad m) => Carrier (Cut :+:
 -- >>> import Test.QuickCheck
 -- >>> import Control.Effect.Void
 -- >>> instance Arbitrary a => Arbitrary (Branch a) where arbitrary = frequency [(1, pure Prune), (1, pure None), (3, Some <$> arbitrary)] ; shrink b = case b of { Some a -> Prune : None : map Some (shrink a) ; None -> [Prune] ; Prune -> [] }
+
+data Branch1 f a
+  = Prune1
+  | None1
+  | Some1 (f a)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+branch1 :: a -> a -> (f b -> a) -> Branch1 f b -> a
+branch1 a _ _ Prune1    = a
+branch1 _ a _ None1     = a
+branch1 _ _ f (Some1 a) = f a
+
+joinBranch1 :: (Alternative f, Monad f) => f (Branch1 f a) -> Branch1 f a
+joinBranch1 = Some1 . (>>= branch1 empty empty id)
+
+instance Applicative f => Applicative (Branch1 f) where
+  pure = Some1 . pure
+
+  Prune1  <*> _       = Prune1
+  _       <*> Prune1  = Prune1
+  None1   <*> _       = None1
+  _       <*> None1   = None1
+  Some1 f <*> Some1 a = Some1 (f <*> a)
+
+instance (Alternative f, Monad f) => Monad (Branch1 f) where
+  return = pure
+
+  Prune1  >>= _ = Prune1
+  None1   >>= _ = None1
+  Some1 a >>= f = Some1 (a >>= branch1 empty empty id . f)
+
+
+runCutAll :: (Alternative m, Carrier sig m, Effect sig, Monad m) => Eff (CutAllC [] m) a -> m a
+runCutAll = (>>= branch1 empty empty (getAlt . foldMap (Alt . pure))) . runCutAllC . interpret
+
+newtype CutAllC f m a = CutAllC { runCutAllC :: m (Branch1 f a) }
+
+instance (Alternative f, Carrier sig m, Effect sig, Monad f, Monad m, Traversable f) => Carrier (Cut :+: NonDet :+: sig) (CutAllC f m) where
+  ret = CutAllC . ret . Some1 . pure
+  eff = CutAllC . handleSum (handleSum
+    (eff . handleTraversable runCutAllC)
+    (\case
+      Empty    -> ret None1
+      Choose k -> runCutAllC (k True) >>= branch1 (ret Prune1) (runCutAllC (k False)) (\ a -> runCutAllC (k False) >>= branch1 (ret (Some1 a)) (ret (Some1 a)) (ret . Some1 . (a <|>)))))
+    (\case
+      Cutfail  -> ret Prune1
+      Call m k -> runCutAllC m >>= branch1 (ret None1) (ret None1) (fmap joinBranch1 . traverse (runCutAllC . k)))

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -77,6 +77,7 @@ branch _ a _ _ None      = a
 branch _ _ f _ (Pure a)  = f a
 branch _ _ _ f (Alt a b) = f a b
 
+-- | Interpret a 'Branch' into an underlying 'Alternative' context.
 runBranch :: Alternative m => Branch m a -> m a
 runBranch = branch empty empty pure (<|>)
 

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -117,4 +117,4 @@ instance (Alternative m, Carrier sig m, Effect sig, Monad m) => Carrier (Cut :+:
 -- >>> :seti -XFlexibleContexts
 -- >>> import Test.QuickCheck
 -- >>> import Control.Effect.Void
--- >>> instance Arbitrary a => Arbitrary (Branch a) where arbitrary = frequency [(1, pure Prune), (1, pure None), (3, Some <$> arbitrary)] ; shrink b = case b of { Some a -> Prune : None : map Some (shrink a) ; None -> [Prune] ; Prune -> [] }
+-- >>> instance Arbitrary a => Arbitrary (Branch a) where arbitrary = frequency [(1, pure Cut), (1, pure None), (3, Some <$> arbitrary)] ; shrink b = case b of { Some a -> Cut : None : map Some (shrink a) ; None -> [Cut] ; Cut -> [] }

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveTraversable, ExistentialQuantification, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Cut
 ( Cut(..)
 , cutfail
@@ -59,7 +59,7 @@ data Branch a
   = Prune
   | None
   | Some a
-  deriving (Eq, Functor, Ord, Show)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 -- | Case analysis for 'Branch', taking a value to use for 'Prune', a value to use for 'None', and a function to apply to the contents of 'Some'.
 --


### PR DESCRIPTION
This PR:

- [x] Adds an `Alt` constructor to `Branch`, and constructs `Alt`s as the interpretation of `Choose`.
- [x] Allows `Cut` to be handled independent of the search strategy for the underlying `Alternative` instance. E.g. `runCut` now composes well with both `runNonDet` and `runNonDetOnce`.
- [x] Fixes #65.