### PR TITLE
Parsing example

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 - Adds a `Cut` effect which adds committed choice to nondeterminism.
 - Fixes the table of contents links in the README.
+- Adds an example of using `NonDet`, `Cut`, and a character parser effect to define parsers.
 
 # 0.1.1.0
 

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -1,7 +1,10 @@
 module Main where
 
+import qualified Parser
 import qualified Teletype
 import Test.Hspec
 
 main :: IO ()
-main = hspec Teletype.spec
+main = hspec $ do
+  Teletype.spec
+  Parser.spec

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,0 +1,1 @@
+module Parser where

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -13,6 +13,10 @@ import Test.QuickCheck
 
 spec :: Spec
 spec = describe "parser" $ do
+  describe "parse" $ do
+    prop "returns pure values at the end of input" $
+      \ a -> run (runNonDetOnce (parse "" (pure a))) == Just (a :: Integer)
+
   describe "satisfy" $ do
     prop "matches with a predicate" $
       \ c f -> run (runNonDetOnce (parse [c] (satisfy (applyFun f)))) == if applyFun f c then Just c else Nothing

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,5 +1,12 @@
 {-# LANGUAGE DeriveFunctor, KindSignatures #-}
 module Parser where
 
+import Control.Effect.Carrier
+import Data.Coerce
+
 data Symbol (m :: * -> *) k = Symbol Char (Char -> k)
   deriving (Functor)
+
+instance HFunctor Symbol where
+  hmap _ = coerce
+  {-# INLINE hmap #-}

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -118,4 +118,6 @@ term
   <|> factor
 
 factor :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
-factor = read <$> some digit
+factor
+  =   read <$> some digit
+  <|> parens expr

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -15,23 +15,23 @@ spec :: Spec
 spec = describe "parser" $ do
   describe "parse" $ do
     prop "returns pure values at the end of input" $
-      \ a -> run (runNonDetOnce (parse "" (pure a))) == Just (a :: Integer)
+      \ a -> run (runNonDet (parse "" (pure a))) == Just (a :: Integer)
 
     prop "fails if input remains" $
-      \ c cs a -> run (runNonDetOnce (parse (c:cs) (pure (a :: Integer)))) == Nothing
+      \ c cs a -> run (runNonDet (parse (c:cs) (pure (a :: Integer)))) == Nothing
 
   describe "satisfy" $ do
     prop "matches with a predicate" $
-      \ c f -> run (runNonDetOnce (parse [c] (satisfy (applyFun f)))) == if applyFun f c then Just c else Nothing
+      \ c f -> run (runNonDet (parse [c] (satisfy (applyFun f)))) == if applyFun f c then Just c else Nothing
 
     prop "fails at end of input" $
-      \ f -> run (runNonDetOnce (parse "" (satisfy (applyFun f)))) == Nothing
+      \ f -> run (runNonDet (parse "" (satisfy (applyFun f)))) == Nothing
 
     prop "fails if input remains" $
-      \ c1 c2 f -> run (runNonDetOnce (parse [c1, c2] (satisfy (applyFun f)))) == Nothing
+      \ c1 c2 f -> run (runNonDet (parse [c1, c2] (satisfy (applyFun f)))) == Nothing
 
     prop "consumes input" $
-      \ c1 c2 f -> run (runNonDetOnce (parse [c1, c2] ((,) <$> satisfy (applyFun f) <*> satisfy (applyFun f)))) == if applyFun f c1 && applyFun f c2 then Just (c1, c2) else Nothing
+      \ c1 c2 f -> run (runNonDet (parse [c1, c2] ((,) <$> satisfy (applyFun f) <*> satisfy (applyFun f)))) == if applyFun f c1 && applyFun f c2 then Just (c1, c2) else Nothing
 
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -50,3 +50,17 @@ instance (Alternative m, Carrier sig m, Effect sig) => Carrier (Symbol :+: sig) 
       c:cs | p c -> runParseC (k c) cs
       _          -> empty)
     op)
+
+
+expr :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
+expr
+  =   (+) <$> term <* char '+' <*> expr
+  <|> term
+
+term :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
+term
+  =   (*) <$> factor <* char '*' <*> term
+  <|> factor
+
+factor :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
+factor = read <$> some digit

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE DeriveFunctor, KindSignatures #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, KindSignatures #-}
 module Parser where
 
 import Control.Effect.Carrier
+import Control.Effect.Sum
 import Data.Coerce
 import Test.Hspec
 
@@ -17,3 +18,6 @@ instance HFunctor Symbol where
 
 instance Effect Symbol where
   handle state handler = coerce . fmap (handler . (<$ state))
+
+satisfy :: (Carrier sig m, Member Symbol sig) => (Char -> Bool) -> m Char
+satisfy p = send (Symbol p ret)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -49,6 +49,9 @@ spec = describe "parser" $ do
     prop "matches factors" $
       \ a -> run (runNonDet (parse (show (abs a)) expr)) == [abs a]
 
+    prop "matches multiplication" $
+      \ as -> run (runNonDet (parse (intercalate "*" (show . abs <$> 1:as)) expr)) == [product (map abs as)]
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -12,6 +12,7 @@ import Test.Hspec
 spec :: Spec
 spec = describe "parser" $ pure ()
 
+
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)
 

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -15,23 +15,23 @@ spec :: Spec
 spec = describe "parser" $ do
   describe "parse" $ do
     prop "returns pure values at the end of input" $
-      \ a -> run (runNonDet (parse "" (pure a))) == Just (a :: Integer)
+      \ a -> run (runNonDet (parse "" (pure a))) == [a :: Integer]
 
     prop "fails if input remains" $
-      \ c cs a -> run (runNonDet (parse (c:cs) (pure (a :: Integer)))) == Nothing
+      \ c cs a -> run (runNonDet (parse (c:cs) (pure (a :: Integer)))) == []
 
   describe "satisfy" $ do
     prop "matches with a predicate" $
-      \ c f -> run (runNonDet (parse [c] (satisfy (applyFun f)))) == if applyFun f c then Just c else Nothing
+      \ c f -> run (runNonDet (parse [c] (satisfy (applyFun f)))) == if applyFun f c then [c] else []
 
     prop "fails at end of input" $
-      \ f -> run (runNonDet (parse "" (satisfy (applyFun f)))) == Nothing
+      \ f -> run (runNonDet (parse "" (satisfy (applyFun f)))) == []
 
     prop "fails if input remains" $
-      \ c1 c2 f -> run (runNonDet (parse [c1, c2] (satisfy (applyFun f)))) == Nothing
+      \ c1 c2 f -> run (runNonDet (parse [c1, c2] (satisfy (applyFun f)))) == []
 
     prop "consumes input" $
-      \ c1 c2 f -> run (runNonDet (parse [c1, c2] ((,) <$> satisfy (applyFun f) <*> satisfy (applyFun f)))) == if applyFun f c1 && applyFun f c2 then Just (c1, c2) else Nothing
+      \ c1 c2 f -> run (runNonDet (parse [c1, c2] ((,) <$> satisfy (applyFun f) <*> satisfy (applyFun f)))) == if applyFun f c1 && applyFun f c2 then [(c1, c2)] else []
 
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -7,6 +7,7 @@ import Control.Effect.NonDet
 import Control.Effect.Sum
 import Data.Char
 import Data.Coerce
+import Data.List (intercalate)
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
@@ -42,7 +43,7 @@ spec = describe "parser" $ do
       \ a -> run (runNonDet (parse (show (abs a)) term)) == [abs a]
 
     prop "matches multiplication" $
-      \ a b -> run (runNonDet (parse (show (abs a) ++ "*" ++ show (abs b)) term)) == [abs a * abs b]
+      \ as -> run (runNonDet (parse (intercalate "*" (show . abs <$> 1:as)) term)) == [product (map abs as)]
 
   describe "expr" $ do
     prop "matches factors" $

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DeriveFunctor, KindSignatures #-}
 module Parser where
 
 data Symbol (m :: * -> *) k = Symbol Char (Char -> k)
+  deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -8,7 +8,7 @@ import Test.Hspec
 spec :: Spec
 spec = describe "parser" $ pure ()
 
-data Symbol (m :: * -> *) k = Symbol Char (Char -> k)
+data Symbol (m :: * -> *) k = Symbol (Char -> Bool) (Char -> k)
   deriving (Functor)
 
 instance HFunctor Symbol where

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -37,6 +37,10 @@ spec = describe "parser" $ do
     prop "matches positive integers" $
       \ a -> run (runNonDet (parse (show (abs a)) factor)) == [abs a]
 
+  describe "term" $ do
+    prop "matches factors" $
+      \ a -> run (runNonDet (parse (show (abs a)) term)) == [abs a]
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -117,9 +117,9 @@ expr = term <**>
   <|> pure id)
 
 term :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
-term
-  =   (*) <$> factor <* char '*' <*> term
-  <|> factor
+term = factor <**>
+  (   (*) <$ char '*' <*> term
+  <|> pure id)
 
 factor :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
 factor

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -27,6 +27,9 @@ spec = describe "parser" $ do
     prop "fails at end of input" $
       \ f -> run (runNonDetOnce (parse "" (satisfy (applyFun f)))) == Nothing
 
+    prop "fails if input remains" $
+      \ c1 c2 f -> run (runNonDetOnce (parse [c1, c2] (satisfy (applyFun f)))) == Nothing
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -103,12 +103,15 @@ newtype ParseC m a = ParseC { runParseC :: String -> m (String, a) }
 
 instance (Alternative m, Carrier sig m, Effect sig) => Carrier (Symbol :+: sig) (ParseC m) where
   ret a = ParseC (\ input -> ret (input, a))
+  {-# INLINE ret #-}
+
   eff op = ParseC (\ input -> handleSum
     (eff . handleState input runParseC)
     (\ (Satisfy p k) -> case input of
       c:cs | p c -> runParseC (k c) cs
       _          -> empty)
     op)
+  {-# INLINE eff #-}
 
 
 expr :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Parser where
 
+import Control.Applicative ((<**>))
 import Control.Effect
 import Control.Effect.Carrier
 import Control.Effect.NonDet
@@ -111,9 +112,9 @@ instance (Alternative m, Carrier sig m, Effect sig) => Carrier (Symbol :+: sig) 
 
 
 expr :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
-expr
-  =   (+) <$> term <* char '+' <*> expr
-  <|> term
+expr = term <**>
+  (   (+) <$ char '+' <*> expr
+  <|> pure id)
 
 term :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
 term

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -30,6 +30,9 @@ spec = describe "parser" $ do
     prop "fails if input remains" $
       \ c1 c2 f -> run (runNonDetOnce (parse [c1, c2] (satisfy (applyFun f)))) == Nothing
 
+    prop "consumes input" $
+      \ c1 c2 f -> run (runNonDetOnce (parse [c1, c2] ((,) <$> satisfy (applyFun f) <*> satisfy (applyFun f)))) == if applyFun f c1 && applyFun f c2 then Just (c1, c2) else Nothing
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,15 +1,17 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, ExistentialQuantification, FlexibleContexts, FlexibleInstances, KindSignatures, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Parser where
 
-import Control.Applicative ((<**>))
 import Control.Effect
 import Control.Effect.Carrier
+import Control.Effect.Cut
 import Control.Effect.NonDet
-import Control.Effect.Sum
+import Control.Effect.Sum hiding (L)
 import Control.Monad (replicateM)
 import Data.Char
 import Data.Coerce
+import Data.Foldable (toList)
 import Data.List (intercalate)
+import Data.Monoid (Alt(..))
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
@@ -38,30 +40,30 @@ spec = describe "parser" $ do
 
   describe "factor" $ do
     prop "matches positive integers" $
-      \ a -> run (runNonDet (parse (show (abs a)) factor)) == [abs a]
+      \ a -> run (runNonDetOnce (runCut2 (parse (show (abs a)) factor))) == [abs a]
 
-    prop "matches parenthesized expressions" .forAll (sized arbNested) $
-      \ as -> run (runNonDet (parse ('(' : intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as) ++ ")") factor)) == [sum (map (product . map abs) as)]
+    prop "matches parenthesized expressions" . forAll (sized arbNested) $
+      \ as -> run (runNonDetOnce (runCut2 (parse ('(' : intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as) ++ ")") factor))) == [sum (map (product . map abs) as)]
 
   describe "term" $ do
     prop "matches factors" $
-      \ a -> run (runNonDet (parse (show (abs a)) term)) == [abs a]
+      \ a -> run (runNonDetOnce (runCut2 (parse (show (abs a)) term))) == [abs a]
 
     prop "matches multiplication" $
-      \ as -> run (runNonDet (parse (intercalate "*" (show . abs <$> 1:as)) term)) == [product (map abs as)]
+      \ as -> run (runNonDetOnce (runCut2 (parse (intercalate "*" (show . abs <$> 1:as)) term))) == [product (map abs as)]
 
   describe "expr" $ do
     prop "matches factors" $
-      \ a -> run (runNonDet (parse (show (abs a)) expr)) == [abs a]
+      \ a -> run (runNonDetOnce (runCut2 (parse (show (abs a)) expr))) == [abs a]
 
     prop "matches multiplication" $
-      \ as -> run (runNonDet (parse (intercalate "*" (show . abs <$> 1:as)) expr)) == [product (map abs as)]
+      \ as -> run (runNonDetOnce (runCut2 (parse (intercalate "*" (show . abs <$> 1:as)) expr))) == [product (map abs as)]
 
     prop "matches addition" $
-      \ as -> run (runNonDet (parse (intercalate "+" (show . abs <$> 0:as)) expr)) == [sum (map abs as)]
+      \ as -> run (runNonDetOnce (runCut2 (parse (intercalate "+" (show . abs <$> 0:as)) expr))) == [sum (map abs as)]
 
     prop "respects order of operations" . forAll (sized arbNested) $
-      \ as -> run (runNonDet (parse (intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as)) expr)) == [sum (map (product . map abs) as)]
+      \ as -> run (runNonDetOnce (runCut2 (parse (intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as)) expr))) == [sum (map (product . map abs) as)]
 
     where arbNested :: Arbitrary a => Int -> Gen [[a]]
           arbNested 0 = pure []
@@ -114,17 +116,159 @@ instance (Alternative m, Carrier sig m, Effect sig) => Carrier (Symbol :+: sig) 
   {-# INLINE eff #-}
 
 
-expr :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
-expr = term <**>
-  (   (+) <$ char '+' <*> expr
-  <|> pure id)
+expr :: (Alternative m, Carrier sig m, Member Cut sig, Member Symbol sig, Monad m) => m Int
+expr = do
+  i <- term
+  call ((i +) <$ char '+' <* cut <*> expr
+    <|> pure i)
 
-term :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
-term = factor <**>
-  (   (*) <$ char '*' <*> term
-  <|> pure id)
+term :: (Alternative m, Carrier sig m, Member Cut sig, Member Symbol sig, Monad m) => m Int
+term = do
+  i <- factor
+  call ((i *) <$ char '*' <* cut <*> term
+    <|> pure i)
 
-factor :: (Alternative m, Carrier sig m, Member Symbol sig) => m Int
+factor :: (Alternative m, Carrier sig m, Member Cut sig, Member Symbol sig, Monad m) => m Int
 factor
   =   read <$> some digit
   <|> parens expr
+
+
+data B a = E | L a | B (B a) (B a)
+  deriving (Functor)
+
+bList :: B a -> [a]
+bList = toList
+
+instance Foldable B where
+  toList = flip go []
+    where go E       rest = rest
+          go (L a)   rest = a : rest
+          go (B a b) rest = go a (go b rest)
+
+  foldMap f = go
+    where go E       = mempty
+          go (L a)   = f a
+          go (B a b) = go a <> go b
+
+  null E = True
+  null _ = False
+
+instance Traversable B where
+  traverse f = go
+    where go E       = pure E
+          go (L a)   = L <$> f a
+          go (B a b) = B <$> go a <*> go b
+
+instance Applicative B where
+  pure = L
+  E     <*> _ = E
+  L f   <*> a = fmap f a
+  B l r <*> a = B (l <*> a) (r <*> a)
+
+instance Alternative B where
+  empty = E
+  E <|> b = b
+  a <|> E = a
+  a <|> b = B a b
+
+instance Monad B where
+  return = pure
+  E     >>= _ = E
+  L a   >>= f = f a
+  B l r >>= f = B (l >>= f) (r >>= f)
+
+
+data Branch1 f a
+  = Prune1
+  | None1
+  | Some1 (f a)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+branch1 :: a -> a -> (f b -> a) -> Branch1 f b -> a
+branch1 a _ _ Prune1    = a
+branch1 _ a _ None1     = a
+branch1 _ _ f (Some1 a) = f a
+
+joinBranch1 :: (Alternative f, Monad f) => f (Branch1 f a) -> Branch1 f a
+joinBranch1 = Some1 . (>>= branch1 empty empty id)
+
+instance Applicative f => Applicative (Branch1 f) where
+  pure = Some1 . pure
+
+  Prune1  <*> _       = Prune1
+  _       <*> Prune1  = Prune1
+  None1   <*> _       = None1
+  _       <*> None1   = None1
+  Some1 f <*> Some1 a = Some1 (f <*> a)
+
+instance (Alternative f, Monad f) => Monad (Branch1 f) where
+  return = pure
+
+  Prune1  >>= _ = Prune1
+  None1   >>= _ = None1
+  Some1 a >>= f = Some1 (a >>= branch1 empty empty id . f)
+
+
+runCutAll :: (Alternative m, Carrier sig m, Effect sig, Monad m) => Eff (CutAllC B m) a -> m a
+runCutAll = (>>= branch1 empty empty (getAlt . foldMap (Alt . pure))) . runCutAllC . interpret
+
+newtype CutAllC f m a = CutAllC { runCutAllC :: m (Branch1 f a) }
+
+instance (Alternative f, Carrier sig m, Effect sig, Monad f, Monad m, Traversable f) => Carrier (Cut :+: NonDet :+: sig) (CutAllC f m) where
+  ret = CutAllC . ret . Some1 . pure
+  eff = CutAllC . handleSum (handleSum
+    (eff . handleTraversable runCutAllC)
+    (\case
+      Empty    -> ret None1
+      Choose k -> runCutAllC (k True) >>= branch1 (ret Prune1) (runCutAllC (k False)) (\ a -> runCutAllC (k False) >>= branch1 (ret (Some1 a)) (ret (Some1 a)) (ret . Some1 . (a <|>)))))
+    (\case
+      Cutfail  -> ret Prune1
+      Call m k -> runCutAllC m >>= branch1 (ret None1) (ret None1) (fmap joinBranch1 . traverse (runCutAllC . k)))
+
+
+data Branch2 m a
+  = Prune2
+  | None2
+  | Some2 a
+  | More2 (m (Branch2 m a)) (m (Branch2 m a))
+  deriving (Functor)
+
+branch2 :: a -> a -> (b -> a) -> (m (Branch2 m b) -> m (Branch2 m b) -> a) -> Branch2 m b -> a
+branch2 a _ _ _ Prune2      = a
+branch2 _ a _ _ None2       = a
+branch2 _ _ f _ (Some2 a)   = f a
+branch2 _ _ _ f (More2 a b) = f a b
+
+joinBranch2 :: (Alternative m, Monad m) => Branch2 m a -> m a
+joinBranch2 = branch2 empty empty pure alt
+  where alt a b = (a >>= joinBranch2) <|> (b >>= joinBranch2)
+
+runCut2 :: (Alternative m, Carrier sig m, Effect sig, Monad m) => Eff (Cut2C m) a -> m a
+runCut2 = (>>= joinBranch2) . runCut2C . interpret
+
+newtype Cut2C m a = Cut2C { runCut2C :: m (Branch2 m a) }
+
+instance (Alternative m, Carrier sig m, Effect sig, Monad m) => Carrier (Cut :+: NonDet :+: sig) (Cut2C m) where
+  ret = Cut2C . ret . Some2
+  eff = Cut2C . handleSum (handleSum
+    (eff . handle (Some2 ()) (branch2
+      (ret Prune2)
+      (ret None2)
+      runCut2C
+      (\ a b -> ret (More2 (a >>= joinBranch2 >>= runCut2C) (b >>= joinBranch2 >>= runCut2C)))))
+    (\case
+      Empty    -> ret None2
+      Choose k -> runCut2C (k True) >>= branch2
+        (ret Prune2)
+        (runCut2C (k False))
+        (\ a -> ret (More2 (ret (Some2 a)) (runCut2C (k False))))
+        (fmap ret . More2)))
+    (\case
+      Cutfail  -> ret Prune2
+      Call m k -> runCut2C m >>= branch2
+        (ret None2)
+        (ret None2)
+        (runCut2C . k)
+        (\ a b -> ret (More2 (a >>= joinBranch2 >>= runCut2C . k) (b >>= joinBranch2 >>= runCut2C . k))))
+-- (\ a b -> (a >>= joinBranch2 >>= runCut2C) <|> (b >>= joinBranch2 >>= runCut2C))

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -41,6 +41,9 @@ spec = describe "parser" $ do
     prop "matches factors" $
       \ a -> run (runNonDet (parse (show (abs a)) term)) == [abs a]
 
+    prop "matches multiplication" $
+      \ a b -> run (runNonDet (parse (show (abs a) ++ "*" ++ show (abs b)) term)) == [abs a * abs b]
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -8,9 +8,14 @@ import Control.Effect.Sum
 import Data.Char
 import Data.Coerce
 import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
 
 spec :: Spec
-spec = describe "parser" $ pure ()
+spec = describe "parser" $ do
+  describe "satisfy" $ do
+    prop "matches with a predicate" $
+      \ c f -> run (runNonDetOnce (parse [c] (satisfy (applyFun f)))) == if applyFun f c then Just c else Nothing
 
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -3,6 +3,10 @@ module Parser where
 
 import Control.Effect.Carrier
 import Data.Coerce
+import Test.Hspec
+
+spec :: Spec
+spec = describe "parser" $ pure ()
 
 data Symbol (m :: * -> *) k = Symbol Char (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -52,6 +52,9 @@ spec = describe "parser" $ do
     prop "matches multiplication" $
       \ as -> run (runNonDet (parse (intercalate "*" (show . abs <$> 1:as)) expr)) == [product (map abs as)]
 
+    prop "matches addition" $
+      \ as -> run (runNonDet (parse (intercalate "+" (show . abs <$> 0:as)) expr)) == [sum (map abs as)]
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveFoldable, DeriveFunctor, DeriveTraversable, ExistentialQuantification, FlexibleContexts, FlexibleInstances, KindSignatures, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
-module Parser where
+module Parser
+( spec
+) where
 
 import Control.Effect
 import Control.Effect.Carrier

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -9,7 +9,7 @@ import Test.Hspec
 spec :: Spec
 spec = describe "parser" $ pure ()
 
-data Symbol (m :: * -> *) k = Symbol (Char -> Bool) (Char -> k)
+data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)
 
 instance HFunctor Symbol where
@@ -20,4 +20,4 @@ instance Effect Symbol where
   handle state handler = coerce . fmap (handler . (<$ state))
 
 satisfy :: (Carrier sig m, Member Symbol sig) => (Char -> Bool) -> m Char
-satisfy p = send (Symbol p ret)
+satisfy p = send (Satisfy p ret)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -21,3 +21,6 @@ instance Effect Symbol where
 
 satisfy :: (Carrier sig m, Member Symbol sig) => (Char -> Bool) -> m Char
 satisfy p = send (Satisfy p ret)
+
+char :: (Carrier sig m, Member Symbol sig) => Char -> m Char
+char = satisfy . (==)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -9,9 +9,7 @@ import Control.Effect.Sum hiding (L)
 import Control.Monad (replicateM)
 import Data.Char
 import Data.Coerce
-import Data.Foldable (toList)
 import Data.List (intercalate)
-import Data.Monoid (Alt(..))
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
@@ -40,30 +38,30 @@ spec = describe "parser" $ do
 
   describe "factor" $ do
     prop "matches positive integers" $
-      \ a -> run (runNonDetOnce (runCut2 (parse (show (abs a)) factor))) == [abs a]
+      \ a -> run (runNonDet (runCut (parse (show (abs a)) factor))) == [abs a]
 
     prop "matches parenthesized expressions" . forAll (sized arbNested) $
-      \ as -> run (runNonDetOnce (runCut2 (parse ('(' : intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as) ++ ")") factor))) == [sum (map (product . map abs) as)]
+      \ as -> run (runNonDet (runCut (parse ('(' : intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as) ++ ")") factor))) == [sum (map (product . map abs) as)]
 
   describe "term" $ do
     prop "matches factors" $
-      \ a -> run (runNonDetOnce (runCut2 (parse (show (abs a)) term))) == [abs a]
+      \ a -> run (runNonDet (runCut (parse (show (abs a)) term))) == [abs a]
 
     prop "matches multiplication" $
-      \ as -> run (runNonDetOnce (runCut2 (parse (intercalate "*" (show . abs <$> 1:as)) term))) == [product (map abs as)]
+      \ as -> run (runNonDet (runCut (parse (intercalate "*" (show . abs <$> 1:as)) term))) == [product (map abs as)]
 
   describe "expr" $ do
     prop "matches factors" $
-      \ a -> run (runNonDetOnce (runCut2 (parse (show (abs a)) expr))) == [abs a]
+      \ a -> run (runNonDet (runCut (parse (show (abs a)) expr))) == [abs a]
 
     prop "matches multiplication" $
-      \ as -> run (runNonDetOnce (runCut2 (parse (intercalate "*" (show . abs <$> 1:as)) expr))) == [product (map abs as)]
+      \ as -> run (runNonDet (runCut (parse (intercalate "*" (show . abs <$> 1:as)) expr))) == [product (map abs as)]
 
     prop "matches addition" $
-      \ as -> run (runNonDetOnce (runCut2 (parse (intercalate "+" (show . abs <$> 0:as)) expr))) == [sum (map abs as)]
+      \ as -> run (runNonDet (runCut (parse (intercalate "+" (show . abs <$> 0:as)) expr))) == [sum (map abs as)]
 
     prop "respects order of operations" . forAll (sized arbNested) $
-      \ as -> run (runNonDetOnce (runCut2 (parse (intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as)) expr))) == [sum (map (product . map abs) as)]
+      \ as -> run (runNonDet (runCut (parse (intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as)) expr))) == [sum (map (product . map abs) as)]
 
     where arbNested :: Arbitrary a => Int -> Gen [[a]]
           arbNested 0 = pure []
@@ -132,143 +130,3 @@ factor :: (Alternative m, Carrier sig m, Member Cut sig, Member Symbol sig, Mona
 factor
   =   read <$> some digit
   <|> parens expr
-
-
-data B a = E | L a | B (B a) (B a)
-  deriving (Functor)
-
-bList :: B a -> [a]
-bList = toList
-
-instance Foldable B where
-  toList = flip go []
-    where go E       rest = rest
-          go (L a)   rest = a : rest
-          go (B a b) rest = go a (go b rest)
-
-  foldMap f = go
-    where go E       = mempty
-          go (L a)   = f a
-          go (B a b) = go a <> go b
-
-  null E = True
-  null _ = False
-
-instance Traversable B where
-  traverse f = go
-    where go E       = pure E
-          go (L a)   = L <$> f a
-          go (B a b) = B <$> go a <*> go b
-
-instance Applicative B where
-  pure = L
-  E     <*> _ = E
-  L f   <*> a = fmap f a
-  B l r <*> a = B (l <*> a) (r <*> a)
-
-instance Alternative B where
-  empty = E
-  E <|> b = b
-  a <|> E = a
-  a <|> b = B a b
-
-instance Monad B where
-  return = pure
-  E     >>= _ = E
-  L a   >>= f = f a
-  B l r >>= f = B (l >>= f) (r >>= f)
-
-
-data Branch1 f a
-  = Prune1
-  | None1
-  | Some1 (f a)
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-branch1 :: a -> a -> (f b -> a) -> Branch1 f b -> a
-branch1 a _ _ Prune1    = a
-branch1 _ a _ None1     = a
-branch1 _ _ f (Some1 a) = f a
-
-joinBranch1 :: (Alternative f, Monad f) => f (Branch1 f a) -> Branch1 f a
-joinBranch1 = Some1 . (>>= branch1 empty empty id)
-
-instance Applicative f => Applicative (Branch1 f) where
-  pure = Some1 . pure
-
-  Prune1  <*> _       = Prune1
-  _       <*> Prune1  = Prune1
-  None1   <*> _       = None1
-  _       <*> None1   = None1
-  Some1 f <*> Some1 a = Some1 (f <*> a)
-
-instance (Alternative f, Monad f) => Monad (Branch1 f) where
-  return = pure
-
-  Prune1  >>= _ = Prune1
-  None1   >>= _ = None1
-  Some1 a >>= f = Some1 (a >>= branch1 empty empty id . f)
-
-
-runCutAll :: (Alternative m, Carrier sig m, Effect sig, Monad m) => Eff (CutAllC B m) a -> m a
-runCutAll = (>>= branch1 empty empty (getAlt . foldMap (Alt . pure))) . runCutAllC . interpret
-
-newtype CutAllC f m a = CutAllC { runCutAllC :: m (Branch1 f a) }
-
-instance (Alternative f, Carrier sig m, Effect sig, Monad f, Monad m, Traversable f) => Carrier (Cut :+: NonDet :+: sig) (CutAllC f m) where
-  ret = CutAllC . ret . Some1 . pure
-  eff = CutAllC . handleSum (handleSum
-    (eff . handleTraversable runCutAllC)
-    (\case
-      Empty    -> ret None1
-      Choose k -> runCutAllC (k True) >>= branch1 (ret Prune1) (runCutAllC (k False)) (\ a -> runCutAllC (k False) >>= branch1 (ret (Some1 a)) (ret (Some1 a)) (ret . Some1 . (a <|>)))))
-    (\case
-      Cutfail  -> ret Prune1
-      Call m k -> runCutAllC m >>= branch1 (ret None1) (ret None1) (fmap joinBranch1 . traverse (runCutAllC . k)))
-
-
-data Branch2 m a
-  = Prune2
-  | None2
-  | Some2 a
-  | More2 (m (Branch2 m a)) (m (Branch2 m a))
-  deriving (Functor)
-
-branch2 :: a -> a -> (b -> a) -> (m (Branch2 m b) -> m (Branch2 m b) -> a) -> Branch2 m b -> a
-branch2 a _ _ _ Prune2      = a
-branch2 _ a _ _ None2       = a
-branch2 _ _ f _ (Some2 a)   = f a
-branch2 _ _ _ f (More2 a b) = f a b
-
-joinBranch2 :: (Alternative m, Monad m) => Branch2 m a -> m a
-joinBranch2 = branch2 empty empty pure alt
-  where alt a b = (a >>= joinBranch2) <|> (b >>= joinBranch2)
-
-runCut2 :: (Alternative m, Carrier sig m, Effect sig, Monad m) => Eff (Cut2C m) a -> m a
-runCut2 = (>>= joinBranch2) . runCut2C . interpret
-
-newtype Cut2C m a = Cut2C { runCut2C :: m (Branch2 m a) }
-
-instance (Alternative m, Carrier sig m, Effect sig, Monad m) => Carrier (Cut :+: NonDet :+: sig) (Cut2C m) where
-  ret = Cut2C . ret . Some2
-  eff = Cut2C . handleSum (handleSum
-    (eff . handle (Some2 ()) (branch2
-      (ret Prune2)
-      (ret None2)
-      runCut2C
-      (\ a b -> ret (More2 (a >>= joinBranch2 >>= runCut2C) (b >>= joinBranch2 >>= runCut2C)))))
-    (\case
-      Empty    -> ret None2
-      Choose k -> runCut2C (k True) >>= branch2
-        (ret Prune2)
-        (runCut2C (k False))
-        (\ a -> ret (More2 (ret (Some2 a)) (runCut2C (k False))))
-        (fmap ret . More2)))
-    (\case
-      Cutfail  -> ret Prune2
-      Call m k -> runCut2C m >>= branch2
-        (ret None2)
-        (ret None2)
-        (runCut2C . k)
-        (\ a b -> ret (More2 (a >>= joinBranch2 >>= runCut2C . k) (b >>= joinBranch2 >>= runCut2C . k))))
--- (\ a b -> (a >>= joinBranch2 >>= runCut2C) <|> (b >>= joinBranch2 >>= runCut2C))

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -31,6 +31,9 @@ char = satisfy . (==)
 digit :: (Carrier sig m, Member Symbol sig) => m Char
 digit = satisfy isDigit
 
+parens :: (Applicative m, Carrier sig m, Member Symbol sig) => m a -> m a
+parens m = char '(' *> m <* char ')'
+
 
 parse :: (Alternative m, Carrier sig m, Effect sig, Monad m) => String -> Eff (ParseC m) a -> m a
 parse input = (>>= exhaustive) . flip runParseC input . interpret

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -33,6 +33,10 @@ spec = describe "parser" $ do
     prop "consumes input" $
       \ c1 c2 f -> run (runNonDet (parse [c1, c2] ((,) <$> satisfy (applyFun f) <*> satisfy (applyFun f)))) == if applyFun f c1 && applyFun f c2 then [(c1, c2)] else []
 
+  describe "factor" $ do
+    prop "matches positive integers" $
+      \ a -> run (runNonDet (parse (show (abs a)) factor)) == [abs a]
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,1 +1,4 @@
+{-# LANGUAGE KindSignatures #-}
 module Parser where
+
+data Symbol (m :: * -> *) k = Symbol Char (Char -> k)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -17,6 +17,9 @@ spec = describe "parser" $ do
     prop "matches with a predicate" $
       \ c f -> run (runNonDetOnce (parse [c] (satisfy (applyFun f)))) == if applyFun f c then Just c else Nothing
 
+    prop "fails at end of input" $
+      \ f -> run (runNonDetOnce (parse "" (satisfy (applyFun f)))) == Nothing
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -17,6 +17,9 @@ spec = describe "parser" $ do
     prop "returns pure values at the end of input" $
       \ a -> run (runNonDetOnce (parse "" (pure a))) == Just (a :: Integer)
 
+    prop "fails if input remains" $
+      \ c cs a -> run (runNonDetOnce (parse (c:cs) (pure (a :: Integer)))) == Nothing
+
   describe "satisfy" $ do
     prop "matches with a predicate" $
       \ c f -> run (runNonDetOnce (parse [c] (satisfy (applyFun f)))) == if applyFun f c then Just c else Nothing

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -10,3 +10,6 @@ data Symbol (m :: * -> *) k = Symbol Char (Char -> k)
 instance HFunctor Symbol where
   hmap _ = coerce
   {-# INLINE hmap #-}
+
+instance Effect Symbol where
+  handle state handler = coerce . fmap (handler . (<$ state))

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -3,6 +3,7 @@ module Parser where
 
 import Control.Effect.Carrier
 import Control.Effect.Sum
+import Data.Char
 import Data.Coerce
 import Test.Hspec
 
@@ -24,3 +25,6 @@ satisfy p = send (Satisfy p ret)
 
 char :: (Carrier sig m, Member Symbol sig) => Char -> m Char
 char = satisfy . (==)
+
+digit :: (Carrier sig m, Member Symbol sig) => m Char
+digit = satisfy isDigit

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -44,6 +44,10 @@ spec = describe "parser" $ do
     prop "matches multiplication" $
       \ a b -> run (runNonDet (parse (show (abs a) ++ "*" ++ show (abs b)) term)) == [abs a * abs b]
 
+  describe "expr" $ do
+    prop "matches factors" $
+      \ a -> run (runNonDet (parse (show (abs a)) expr)) == [abs a]
+
 
 data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
   deriving (Functor)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -39,6 +39,9 @@ spec = describe "parser" $ do
     prop "matches positive integers" $
       \ a -> run (runNonDet (parse (show (abs a)) factor)) == [abs a]
 
+    prop "matches parenthesized expressions" .forAll (sized arbNested) $
+      \ as -> run (runNonDet (parse ('(' : intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as) ++ ")") factor)) == [sum (map (product . map abs) as)]
+
   describe "term" $ do
     prop "matches factors" $
       \ a -> run (runNonDet (parse (show (abs a)) term)) == [abs a]

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -57,6 +57,7 @@ test-suite examples
   build-depends:       base >=4.9 && <4.12
                      , fused-effects
                      , hspec >=2.4.1
+                     , QuickCheck >= 2.7 && < 2.12
   hs-source-dirs:      examples
   default-language:    Haskell2010
 

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -52,7 +52,8 @@ library
 test-suite examples
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
-  other-modules:       Teletype
+  other-modules:       Parser
+                     , Teletype
   build-depends:       base >=4.9 && <4.12
                      , fused-effects
                      , hspec >=2.4.1

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -21,6 +21,7 @@ class HFunctor h where
   fmap' :: (a -> b) -> (h m a -> h m b)
   default fmap' :: Functor (h m) => (a -> b) -> (h m a -> h m b)
   fmap' = fmap
+  {-# INLINE fmap' #-}
 
   -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
   hmap :: (forall x . m x -> n x) -> (h m a -> h n a)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -35,6 +35,7 @@ handleSum :: (          sig2  m a -> b)
           -> ((sig1 :+: sig2) m a -> b)
 handleSum alg1 _    (R op) = alg1 op
 handleSum _    alg2 (L op) = alg2 op
+{-# INLINE handleSum #-}
 
 
 class Member (sub :: (* -> *) -> (* -> *)) sup where
@@ -59,3 +60,4 @@ instance {-# OVERLAPPABLE #-} Member sub sup => Member sub (sub' :+: sup) where
 -- | Construct a request for an effect to be interpreted by some handler later on.
 send :: (Member effect sig, Carrier sig m) => effect m (m a) -> m a
 send = eff . inj
+{-# INLINE send #-}

--- a/src/Control/Effect/Void.hs
+++ b/src/Control/Effect/Void.hs
@@ -13,17 +13,23 @@ data Void (m :: * -> *) k
 
 instance HFunctor Void where
   hmap _ v = case v of {}
+  {-# INLINE hmap #-}
 
 instance Effect Void where
   handle _ _ v = case v of {}
+  {-# INLINE handle #-}
 
 
 -- | Run an 'Eff' exhausted of effects to produce its final result value.
 run :: Eff VoidC a -> a
 run = runVoidC . interpret
+{-# INLINE run #-}
 
 newtype VoidC a = VoidC { runVoidC :: a }
 
 instance Carrier Void VoidC where
   ret = VoidC
+  {-# INLINE ret #-}
+
   eff v = case v of {}
+  {-# INLINE eff #-}


### PR DESCRIPTION
This PR develops an example of using `fused-effects` to write parsers, following _Effect Handlers in Scope_, §6. In particular, it shows the combination of `NonDet`, `Cut`, and a custom `Symbol` effect to implement a grammar for simple arithmetic expressions (lacking whitespace).