### PR TITLE
Proposal: Asynchronous effect

### DIFF
--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -20,6 +20,7 @@ tested-with:         GHC == 8.2.2
 
 library
   exposed-modules:     Control.Effect
+                     , Control.Effect.Async
                      , Control.Effect.Carrier
                      , Control.Effect.Cut
                      , Control.Effect.Error
@@ -42,6 +43,7 @@ library
                      , Control.Effect.Void
                      , Control.Effect.Writer
   build-depends:       base >=4.9 && <4.12
+                     , async >= 2.1 && <2.3
                      , deepseq >=1.4.3 && <1.5
                      , MonadRandom >=0.5 && <0.6
                      , random

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -2,6 +2,7 @@ module Control.Effect
 ( module X
 ) where
 
+import Control.Effect.Async     as X (Asynchronous, AsynchronousC)
 import Control.Effect.Carrier   as X (Carrier, Effect)
 import Control.Effect.Cut       as X (Cut, CutC)
 import Control.Effect.Error     as X (Error, ErrorC)

--- a/src/Control/Effect/Async.hs
+++ b/src/Control/Effect/Async.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GADTs,
+             MultiParamTypeClasses, RankNTypes, StandaloneDeriving, TypeOperators, UndecidableInstances, LambdaCase #-}
+module Control.Effect.Async
+  ( Asynchronous (..)
+  , async
+  , asyncBound
+  , wait
+  , poll
+  , runAsynchronous
+  , AsynchronousC (..)
+  -- | Re-exports from Control.Concurrent.Async
+  , Async
+  , cancel
+  ) where
+
+import           Control.Concurrent.Async (Async, asyncThreadId, cancel, poll)
+import qualified Control.Concurrent.Async as C
+import           Control.Monad.IO.Class
+import           Control.Exception (SomeException)
+
+import Control.Effect.Carrier
+import Control.Effect.Internal
+import Control.Effect.Sum
+
+data Spawn = ForkIO | ForkOS | ForkOn Int
+data MaskSpawn = MaskIO | MaskOn Int
+
+data Asynchronous m k where
+  MkAsync :: Spawn -> m a -> (Async a -> k) -> Asynchronous m k
+  Wait    :: Async a -> (a -> k) -> Asynchronous m k
+
+instance Functor (Asynchronous m) where
+  fmap f (MkAsync s m k) = MkAsync s m (f . k)
+  fmap f (Wait a k) = Wait a (f . k)
+
+instance HFunctor Asynchronous where
+  hmap f (MkAsync s m k) = MkAsync s (f m) k
+  hmap f (Wait a k)    = Wait a k
+
+-- | Spawn an asynchronous action in a separate thread.
+-- The 'asyncWithUnmask' function is not provided due to
+-- implementation details that prevent correct typing.
+async :: (Member Asynchronous sig, Carrier sig m) => m a -> m (Async a)
+async act = send (MkAsync ForkIO act ret)
+
+-- | Like 'async' but using 'forkOS' internally.
+asyncBound :: (Member Asynchronous sig, Carrier sig m) => m a -> m (Async a)
+asyncBound act = send (MkAsync ForkOS act ret)
+
+-- | Like 'async' but using 'forkOn' internally.
+asyncOn :: (Member Asynchronous sig, Carrier sig m) => Int -> m a -> m (Async a)
+asyncOn n act = send (MkAsync (ForkOn n) act ret)
+
+-- | Wait for an asynchronous action to complete, and return its
+-- value. If the asynchronous action threw an exception, then the
+-- exception is re-thrown by wait.
+wait :: (Member Asynchronous sig, Carrier sig m) => Async a -> m a
+wait it = send (Wait it ret)
+
+-- | Run computations asynchronously in a 'MonadIO'.
+runAsynchronous :: (Carrier sig m, MonadIO m)
+                => (forall x . m x -> IO x)
+                -> Eff (AsynchronousC m) a
+                -> m a
+runAsynchronous handler = runAsynchronousC handler . interpret
+
+newtype AsynchronousC m a = AsynchronousC ((forall x . m x -> IO x) -> m a)
+
+runAsynchronousC :: (forall x . m x -> IO x) -> AsynchronousC m a -> m a
+runAsynchronousC handler (AsynchronousC m) = m handler
+
+instance (Carrier sig m, MonadIO m) => Carrier (Asynchronous :+: sig) (AsynchronousC m) where
+  ret a = AsynchronousC (const (ret a))
+  eff op = AsynchronousC (\handler -> handleSum
+                                      (eff . handlePure (runAsynchronousC handler))
+                                      (\case
+                                          (MkAsync ForkIO act k) -> liftIO (C.async (handler (runAsynchronousC handler act))) >>= runAsynchronousC handler . k
+                                          (MkAsync ForkOS act k) -> liftIO (C.asyncBound (handler (runAsynchronousC handler act))) >>= runAsynchronousC handler . k
+                                          (MkAsync (ForkOn n) act k) -> liftIO (C.asyncOn n (handler (runAsynchronousC handler act))) >>= runAsynchronousC handler . k
+                                          (Wait it k) -> liftIO (C.wait it) >>= runAsynchronousC handler . k
+                                      )
+                                      op)
+  -- eff op = AsynchronousC (\ handler -> handleSum
+  --   (eff . handlePure (runAsynchronousC handler))
+  --   (\ (MkAsync act k) -> _))-- liftIO (C.async (handler act))
+  --     -- >>= runAsynchronousC handler . k) op)

--- a/src/Control/Effect/Async.hs
+++ b/src/Control/Effect/Async.hs
@@ -23,7 +23,6 @@ import Control.Effect.Internal
 import Control.Effect.Sum
 
 data Spawn = ForkIO | ForkOS | ForkOn Int
-data MaskSpawn = MaskIO | MaskOn Int
 
 data Asynchronous m k where
   MkAsync :: Spawn -> m a -> (Async a -> k) -> Asynchronous m k

--- a/src/Control/Effect/Async.hs
+++ b/src/Control/Effect/Async.hs
@@ -80,7 +80,3 @@ instance (Carrier sig m, MonadIO m) => Carrier (Asynchronous :+: sig) (Asynchron
                                           (Wait it k) -> liftIO (C.wait it) >>= runAsynchronousC handler . k
                                       )
                                       op)
-  -- eff op = AsynchronousC (\ handler -> handleSum
-  --   (eff . handlePure (runAsynchronousC handler))
-  --   (\ (MkAsync act k) -> _))-- liftIO (C.async (handler act))
-  --     -- >>= runAsynchronousC handler . k) op)


### PR DESCRIPTION
This adds an `Asynchronous` effect that provides an effectful
interface to that provided by Control.Concurrent.Async.

This could be good to include for convenience's sake (since the
`async`, `asyncBound`, and `asyncOn` functions cannot be implemented
solely in terms of `liftIO`), and might also make for a good demo.
On the other hand, it entails a new dependency on `async`, though
`async` is ubiquitous, and does not provide all the functionality
of Control.Concurrent.Async, as the withUnmask family of functions
does not have proper variance.

I am not married to this module living in fused-effects; it's possible
that a dependent package is the best place for this. Whether or not it
belongs in mainline is a philosophical question: do we want to be a
batteries-included framework, or do we want to encourage minimalism?