### PR TITLE
Make doctest component depend on random.

### DIFF
--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -79,6 +79,7 @@ test-suite doctest
   main-is:             Doctest.hs
   build-depends:       base >=4.9 && <4.13
                      , doctest >=0.7 && <1.0
+                     , random
   hs-source-dirs:      test
   default-language:    Haskell2010
 


### PR DESCRIPTION
This should hopefully squash some of the CI failures we've been seeing.