### PR TITLE
No functor constraint on asks

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+- Removes the `Functor` constraint on `asks`.
+
 # 0.1.2.1
 
 - Loosens the bounds on QuickCheck to accommodate 0.12.

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -35,8 +35,8 @@ ask = send (Ask ret)
 -- | Project a function out of the current environment value.
 --
 --   prop> snd (run (runReader a (asks (applyFun f)))) == applyFun f a
-asks :: (Member (Reader r) sig, Carrier sig m, Functor m) => (r -> a) -> m a
-asks f = fmap f ask
+asks :: (Member (Reader r) sig, Carrier sig m) => (r -> a) -> m a
+asks f = send (Ask (ret . f))
 
 -- | Run a computation with an environment value locally modified by the passed function.
 --


### PR DESCRIPTION
This PR:

- [x] 🔥s the unnecessary `Functor` constraint on `asks` by defining it w.r.t. the `Ask` constructor directly, rather than in terms of `ask` and `fmap`.
- [x] Fixes #84.