### PR TITLE
Writer space leak fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+- Adds benchmarks of `WriterC`/`VoidC` wrapped with `Eff` against their unwrapped counterparts.
+- Adds `Functor`, `Applicative`, and `Monad` instances for `WriterC`.
+- Adds `Functor`, `Applicative`, and `Monad` instances for `VoidC`.
+- Fixes a space leak with `WriterC`.
 - Removes the `Functor` constraint on `asks`.
 
 # 0.1.2.1

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = pure ()

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,4 +1,28 @@
+{-# LANGUAGE FlexibleContexts, TypeApplications, TypeOperators #-}
 module Main where
 
+import Control.Effect
+import Control.Effect.Void
+import Control.Effect.Writer
+import Control.Monad (replicateM_)
+import Criterion.Main
+import Data.Monoid (Sum(..))
+
 main :: IO ()
-main = pure ()
+main = defaultMain
+  [ bgroup "WriterC"
+    [ bgroup "Eff"
+      [ bench "100"       $ whnf (run . execWriter @_ @_ @(Sum Int) . tellLoop) 100
+      , bench "100000"    $ whnf (run . execWriter @_ @_ @(Sum Int) . tellLoop) 100000
+      , bench "100000000" $ whnf (run . execWriter @_ @_ @(Sum Int) . tellLoop) 100000000
+      ]
+    , bgroup "standalone"
+      [ bench "100"       $ whnf (fst . runVoidC . flip runWriterC (Sum (0 :: Int)) . tellLoop) 100
+      , bench "100000"    $ whnf (fst . runVoidC . flip runWriterC (Sum (0 :: Int)) . tellLoop) 100000
+      , bench "100000000" $ whnf (fst . runVoidC . flip runWriterC (Sum (0 :: Int)) . tellLoop) 100000000
+      ]
+    ]
+  ]
+
+tellLoop :: (Applicative m, Carrier sig m, Member (Writer (Sum Int)) sig) => Int -> m ()
+tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -55,6 +55,15 @@ library
   if (impl(ghc >= 8.6))
     ghc-options:       -Wno-star-is-type
 
+benchmark benchmark
+  type:               exitcode-stdio-1.0
+  main-is:            Bench.hs
+  build-depends:      base >=4.9 && <4.13
+                    , fused-effects
+  hs-source-dirs:     benchmark
+  default-language:   Haskell2010
+  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m" -j
+
 
 test-suite examples
   type:                exitcode-stdio-1.0

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -55,16 +55,6 @@ library
   if (impl(ghc >= 8.6))
     ghc-options:       -Wno-star-is-type
 
-benchmark benchmark
-  type:               exitcode-stdio-1.0
-  main-is:            Bench.hs
-  build-depends:      base >=4.9 && <4.13
-                    , criterion
-                    , fused-effects
-  hs-source-dirs:     benchmark
-  default-language:   Haskell2010
-  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"
-
 
 test-suite examples
   type:                exitcode-stdio-1.0
@@ -96,6 +86,18 @@ test-suite doctest
                      , doctest >=0.7 && <1.0
   hs-source-dirs:      test
   default-language:    Haskell2010
+
+
+benchmark benchmark
+  type:               exitcode-stdio-1.0
+  main-is:            Bench.hs
+  build-depends:      base >=4.9 && <4.13
+                    , criterion
+                    , fused-effects
+  hs-source-dirs:     benchmark
+  default-language:   Haskell2010
+  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"
+
 
 source-repository head
   type:     git

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -59,6 +59,7 @@ benchmark benchmark
   type:               exitcode-stdio-1.0
   main-is:            Bench.hs
   build-depends:      base >=4.9 && <4.13
+                    , criterion
                     , fused-effects
   hs-source-dirs:     benchmark
   default-language:   Haskell2010

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -63,7 +63,7 @@ benchmark benchmark
                     , fused-effects
   hs-source-dirs:     benchmark
   default-language:   Haskell2010
-  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m" -j
+  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"
 
 
 test-suite examples

--- a/src/Control/Effect/Void.hs
+++ b/src/Control/Effect/Void.hs
@@ -27,6 +27,24 @@ run = runVoidC . interpret
 
 newtype VoidC a = VoidC { runVoidC :: a }
 
+instance Functor VoidC where
+  fmap f (VoidC a) = VoidC (f a)
+  {-# INLINE fmap #-}
+
+instance Applicative VoidC where
+  pure = VoidC
+  {-# INLINE pure #-}
+
+  VoidC f <*> VoidC a = VoidC (f a)
+  {-# INLINE (<*>) #-}
+
+instance Monad VoidC where
+  return = pure
+  {-# INLINE return #-}
+
+  VoidC a >>= f = f a
+  {-# INLINE (>>=) #-}
+
 instance Carrier Void VoidC where
   ret = VoidC
   {-# INLINE ret #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -21,6 +21,7 @@ instance HFunctor (Writer w) where
 
 instance Effect (Writer w) where
   handle state handler (Tell w k) = Tell w (handler (k <$ state))
+  {-# INLINE handle #-}
 
 -- | Write a value to the log.
 --

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -46,6 +46,9 @@ execWriter = fmap fst . runWriter
 {-# INLINE execWriter #-}
 
 
+-- | A space-efficient carrier for 'Writer' effects.
+--
+--   This is based on a post Gabriel Gonzalez made to the Haskell mailing list: https://mail.haskell.org/pipermail/libraries/2013-March/019528.html
 newtype WriterC w m a = WriterC { runWriterC :: w -> m (w, a) }
 
 instance Functor m => Functor (WriterC w m) where

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -49,6 +49,8 @@ execWriter = fmap fst . runWriter
 -- | A space-efficient carrier for 'Writer' effects.
 --
 --   This is based on a post Gabriel Gonzalez made to the Haskell mailing list: https://mail.haskell.org/pipermail/libraries/2013-March/019528.html
+--
+--   Note that currently, the constant-space behaviour observed there only occurs when using 'WriterC' and 'VoidC' without 'Eff' wrapping them. See the @benchmark@ component for details.
 newtype WriterC w m a = WriterC { runWriterC :: w -> m (w, a) }
 
 instance Functor m => Functor (WriterC w m) where

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -28,6 +28,7 @@ instance Effect (Writer w) where
 --   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) == foldMap Sum ws
 tell :: (Member (Writer w) sig, Carrier sig m) => w -> m ()
 tell w = send (Tell w (ret ()))
+{-# INLINE tell #-}
 
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log alongside the result value.
@@ -35,22 +36,27 @@ tell w = send (Tell w (ret ()))
 --   prop> run (runWriter (tell (Sum a) *> pure b)) == (Sum a, b)
 runWriter :: (Carrier sig m, Effect sig, Monoid w) => Eff (WriterC w m) a -> m (w, a)
 runWriter m = runWriterC (interpret m) mempty
+{-# INLINE runWriter #-}
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
 --
 --   prop> run (execWriter (tell (Sum a) *> pure b)) == Sum a
 execWriter :: (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m w
 execWriter = fmap fst . runWriter
+{-# INLINE execWriter #-}
 
 
 newtype WriterC w m a = WriterC { runWriterC :: w -> m (w, a) }
 
 instance (Monoid w, Carrier sig m, Effect sig) => Carrier (Writer w :+: sig) (WriterC w m) where
   ret a = WriterC (\ w -> ret (w, a))
+  {-# INLINE ret #-}
+
   eff op = WriterC (\ w -> handleSum
     (eff . handleState w runWriterC)
     (\ (Tell w' k) -> let w'' = mappend w w' in w'' `seq` runWriterC k w'')
     op)
+  {-# INLINE eff #-}
 
 
 -- $setup

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -10,7 +10,6 @@ module Control.Effect.Writer
 import Control.Effect.Carrier
 import Control.Effect.Sum
 import Control.Effect.Internal
-import Control.Monad (ap)
 import Data.Coerce
 
 data Writer w (m :: * -> *) k = Tell w k
@@ -57,7 +56,11 @@ instance (Monad m, Monoid w) => Applicative (WriterC w m) where
   pure a = WriterC $ \w -> pure (w, a)
   {-# INLINE pure #-}
 
-  (<*>) = ap
+  WriterC f <*> WriterC a = WriterC $ \ w -> do
+    (w', f') <- f w
+    (w'', a') <- a w'
+    let fa = f' a'
+    fa `seq` pure (w'', fa)
   {-# INLINE (<*>) #-}
 
 instance (Monad m, Monoid w) => Monad (WriterC w m) where

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -56,6 +56,7 @@ instance Functor m => Functor (WriterC w m) where
 instance (Monad m, Monoid w) => Applicative (WriterC w m) where
   pure a = WriterC $ \w -> pure (w, a)
   {-# INLINE pure #-}
+
   (<*>) = ap
   {-# INLINE (<*>) #-}
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -40,7 +40,7 @@ runWriter m = runWriterC (interpret m)
 --
 --   prop> run (execWriter (tell (Sum a) *> pure b)) == Sum a
 execWriter :: (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m w
-execWriter m = fmap fst (runWriterC (interpret m))
+execWriter = fmap fst . runWriter
 
 
 newtype WriterC w m a = WriterC { runWriterC :: m (w, a) }


### PR DESCRIPTION
This PR:

- [x] Adds `Functor`, `Applicative`, and `Monad` instances for `VoidC` and `WriterC`.
- [x] Adds benchmarks of `WriterC`/`VoidC` against their `Eff`-wrapped counterparts. (cf #89)
- [x] Fixes #85.