### PR TITLE
Writer functionality

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,4 @@
+- Adds `listen`, `listens`, and `censor` operations to `Writer`.
 - Adds benchmarks of `WriterC`/`VoidC` wrapped with `Eff` against their unwrapped counterparts.
 - Adds `Functor`, `Applicative`, and `Monad` instances for `WriterC`.
 - Adds `Functor`, `Applicative`, and `Monad` instances for `VoidC`.

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -49,7 +49,7 @@ listen m = send (Listen m (curry ret))
 
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
---   prop> run (runWriter (tell (Sum a) *> listens @(Sum Integer) fst (tell (Sum b)))) == (Sum a <> Sum b, Sum b)
+--   prop> run (runWriter (fst <$ tell (Sum a) <*> listens @(Sum Integer) (applyFun f) (tell (Sum b)))) == (Sum a <> Sum b, applyFun f (Sum b))
 listens :: (Member (Writer w) sig, Carrier sig m) => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry ret . f))
 {-# INLINE listens #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -39,6 +39,7 @@ tell :: (Member (Writer w) sig, Carrier sig m) => w -> m ()
 tell w = send (Tell w (ret ()))
 {-# INLINE tell #-}
 
+-- | Run a computation, returning the pair of its output and its result.
 listen :: (Member (Writer w) sig, Carrier sig m) => m a -> m (w, a)
 listen m = send (Listen m (curry ret))
 {-# INLINE listen #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -36,6 +36,8 @@ tell w = send (Tell w (ret ()))
 {-# INLINE tell #-}
 
 -- | Run a computation, modifying its output with the passed function.
+--
+--   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) == applyFun f (Sum a)
 censor :: (Member (Writer w) sig, Carrier sig m) => (w -> w) -> m a -> m a
 censor f m = send (Censor f m ret)
 {-# INLINE censor #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -35,6 +35,7 @@ tell :: (Member (Writer w) sig, Carrier sig m) => w -> m ()
 tell w = send (Tell w (ret ()))
 {-# INLINE tell #-}
 
+-- | Run a computation, modifying its output with the passed function.
 censor :: (Member (Writer w) sig, Carrier sig m) => (w -> w) -> m a -> m a
 censor f m = send (Censor f m ret)
 {-# INLINE censor #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -38,6 +38,7 @@ tell w = send (Tell w (ret ()))
 -- | Run a computation, modifying its output with the passed function.
 --
 --   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) == applyFun f (Sum a)
+--   prop> run (execWriter (tell (Sum a) *> censor (applyFun f) (tell (Sum b)) *> tell (Sum c))) == (Sum a <> applyFun f (Sum b) <> Sum c)
 censor :: (Member (Writer w) sig, Carrier sig m) => (w -> w) -> m a -> m a
 censor f m = send (Censor f m ret)
 {-# INLINE censor #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -132,4 +132,4 @@ instance (Monoid w, Carrier sig m, Effect sig, Monad m) => Carrier (Writer w :+:
 -- >>> :seti -XTypeApplications
 -- >>> import Test.QuickCheck
 -- >>> import Control.Effect.Void
--- >>> import Data.Monoid (Sum(..))
+-- >>> import Data.Semigroup (Semigroup(..), Sum(..))

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -42,14 +42,14 @@ tell w = send (Tell w (ret ()))
 
 -- | Run a computation, returning the pair of its output and its result.
 --
---   prop> run (runWriter (fst <$ tell (Sum a) <*> listen (tell (Sum b)))) == (Sum a <> Sum b, Sum b)
+--   prop> run (runWriter (fst <$ tell (Sum a) <*> listen @(Sum Integer) (tell (Sum b)))) == (Sum a <> Sum b, Sum b)
 listen :: (Member (Writer w) sig, Carrier sig m) => m a -> m (w, a)
 listen m = send (Listen m (curry ret))
 {-# INLINE listen #-}
 
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
---   prop> run (runWriter (tell (Sum a) *> listens fst (tell (Sum b)))) == (Sum a <> Sum b, Sum b)
+--   prop> run (runWriter (tell (Sum a) *> listens @(Sum Integer) fst (tell (Sum b)))) == (Sum a <> Sum b, Sum b)
 listens :: (Member (Writer w) sig, Carrier sig m) => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry ret . f))
 {-# INLINE listens #-}
@@ -129,6 +129,7 @@ instance (Monoid w, Carrier sig m, Effect sig, Monad m) => Carrier (Writer w :+:
 
 -- $setup
 -- >>> :seti -XFlexibleContexts
+-- >>> :seti -XTypeApplications
 -- >>> import Test.QuickCheck
 -- >>> import Control.Effect.Void
 -- >>> import Data.Monoid (Sum(..))

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -3,6 +3,7 @@ module Control.Effect.Writer
 ( Writer(..)
 , tell
 , listen
+, listens
 , censor
 , runWriter
 , execWriter
@@ -43,6 +44,10 @@ tell w = send (Tell w (ret ()))
 listen :: (Member (Writer w) sig, Carrier sig m) => m a -> m (w, a)
 listen m = send (Listen m (curry ret))
 {-# INLINE listen #-}
+
+listens :: (Member (Writer w) sig, Carrier sig m) => (w -> b) -> m a -> m (b, a)
+listens f m = send (Listen m (curry ret . f))
+{-# INLINE listens #-}
 
 -- | Run a computation, modifying its output with the passed function.
 --

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -41,6 +41,8 @@ tell w = send (Tell w (ret ()))
 {-# INLINE tell #-}
 
 -- | Run a computation, returning the pair of its output and its result.
+--
+--   prop> run (runWriter (fst <$ tell (Sum a) <*> listen (tell (Sum b)))) == (Sum a <> Sum b, Sum b)
 listen :: (Member (Writer w) sig, Carrier sig m) => m a -> m (w, a)
 listen m = send (Listen m (curry ret))
 {-# INLINE listen #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -48,6 +48,8 @@ listen m = send (Listen m (curry ret))
 {-# INLINE listen #-}
 
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
+--
+--   prop> run (runWriter (tell (Sum a) *> listens fst (tell (Sum b)))) == (Sum a <> Sum b, Sum b)
 listens :: (Member (Writer w) sig, Carrier sig m) => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry ret . f))
 {-# INLINE listens #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -45,6 +45,7 @@ listen :: (Member (Writer w) sig, Carrier sig m) => m a -> m (w, a)
 listen m = send (Listen m (curry ret))
 {-# INLINE listen #-}
 
+-- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 listens :: (Member (Writer w) sig, Carrier sig m) => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry ret . f))
 {-# INLINE listens #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -2,6 +2,7 @@
 module Control.Effect.Writer
 ( Writer(..)
 , tell
+, censor
 , runWriter
 , execWriter
 , WriterC(..)
@@ -33,6 +34,10 @@ instance Effect (Writer w) where
 tell :: (Member (Writer w) sig, Carrier sig m) => w -> m ()
 tell w = send (Tell w (ret ()))
 {-# INLINE tell #-}
+
+censor :: (Member (Writer w) sig, Carrier sig m) => (w -> w) -> m a -> m a
+censor f m = send (Censor f m ret)
+{-# INLINE censor #-}
 
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log alongside the result value.


### PR DESCRIPTION
This PR:

- [x] Depends on #90.
- [x] Implements `censor`, allowing local modification of a computation’s output.
- [x] Implements `listen`, allowing observation of a computation’s output.
- [x] Implements `listens`, allowing mapped observation of a computation’s output.
- [x] Fixes #83.