### PR TITLE
Provide explicit type parameters in State/Reader/Writer.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 - Fixes a space leak with `WriterC`.
 - Removes the `Functor` constraint on `asks`.
 - Provides explicit type parameters to `run`-style functions in `State`, `Reader`, and `Writer`. 
-  This may be a backwards-incompatible change for clients using these functons in combination
+  This is a backwards-incompatible change for clients using these functions in combination
   with visible type applications.
 
 # 0.1.2.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@
 - Adds `Functor`, `Applicative`, and `Monad` instances for `VoidC`.
 - Fixes a space leak with `WriterC`.
 - Removes the `Functor` constraint on `asks`.
+- Provides explicit type parameters to `run`-style functions in `State`, `Reader`, and `Writer`. 
+  This may a backwards-incompatible change for clients using these functons in combination
+  with visible type applications.
 
 # 0.1.2.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 - Fixes a space leak with `WriterC`.
 - Removes the `Functor` constraint on `asks`.
 - Provides explicit type parameters to `run`-style functions in `State`, `Reader`, and `Writer`. 
-  This may a backwards-incompatible change for clients using these functons in combination
+  This may be a backwards-incompatible change for clients using these functons in combination
   with visible type applications.
 
 # 0.1.2.1

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -49,7 +49,7 @@ local f m = send (Local f m ret)
 -- | Run a 'Reader' effect with the passed environment value.
 --
 --   prop> run (runReader a (pure b)) == b
-runReader :: (Carrier sig m, Monad m) => r -> Eff (ReaderC r m) a -> m a
+runReader :: forall r m a sig . (Carrier sig m, Monad m) => r -> Eff (ReaderC r m) a -> m a
 runReader r m = runReaderC (interpret m) r
 
 newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -49,7 +49,7 @@ local f m = send (Local f m ret)
 -- | Run a 'Reader' effect with the passed environment value.
 --
 --   prop> run (runReader a (pure b)) == b
-runReader :: forall r m a sig . (Carrier sig m, Monad m) => r -> Eff (ReaderC r m) a -> m a
+runReader :: forall r sig m a . (Carrier sig m, Monad m) => r -> Eff (ReaderC r m) a -> m a
 runReader r m = runReaderC (interpret m) r
 
 newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -61,13 +61,13 @@ modify f = do
 -- | Run a 'State' effect starting from the passed value.
 --
 --   prop> run (runState a (pure b)) == (a, b)
-runState :: forall s m a sig . (Carrier sig m, Effect sig) => s -> Eff (StateC s m) a -> m (s, a)
+runState :: forall s sig m a . (Carrier sig m, Effect sig) => s -> Eff (StateC s m) a -> m (s, a)
 runState s m = runStateC (interpret m) s
 
 -- | Run a 'State' effect, yielding the result value and discarding the final state.
 --
 --   prop> run (evalState a (pure b)) == b
-evalState :: forall s m a sig . (Carrier sig m, Effect sig, Functor m) => s -> Eff (StateC s m) a -> m a
+evalState :: forall s sig m a . (Carrier sig m, Effect sig, Functor m) => s -> Eff (StateC s m) a -> m a
 evalState s m = fmap snd (runStateC (interpret m) s)
 
 -- | Run a 'State' effect, yielding the final state and discarding the return value.

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, KindSignatures, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State
 ( State(..)
 , get
@@ -61,19 +61,19 @@ modify f = do
 -- | Run a 'State' effect starting from the passed value.
 --
 --   prop> run (runState a (pure b)) == (a, b)
-runState :: (Carrier sig m, Effect sig) => s -> Eff (StateC s m) a -> m (s, a)
+runState :: forall s m a sig . (Carrier sig m, Effect sig) => s -> Eff (StateC s m) a -> m (s, a)
 runState s m = runStateC (interpret m) s
 
 -- | Run a 'State' effect, yielding the result value and discarding the final state.
 --
 --   prop> run (evalState a (pure b)) == b
-evalState :: (Carrier sig m, Effect sig, Functor m) => s -> Eff (StateC s m) a -> m a
+evalState :: forall s m a sig . (Carrier sig m, Effect sig, Functor m) => s -> Eff (StateC s m) a -> m a
 evalState s m = fmap snd (runStateC (interpret m) s)
 
 -- | Run a 'State' effect, yielding the final state and discarding the return value.
 --
 --   prop> run (execState a (pure b)) == a
-execState :: (Carrier sig m, Effect sig, Functor m) => s -> Eff (StateC s m) a -> m s
+execState :: forall s sig m a . (Carrier sig m, Effect sig, Functor m) => s -> Eff (StateC s m) a -> m s
 execState s m = fmap fst (runStateC (interpret m) s)
 
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -34,14 +34,14 @@ tell w = send (Tell w (ret ()))
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log alongside the result value.
 --
 --   prop> run (runWriter (tell (Sum a) *> pure b)) == (Sum a, b)
-runWriter :: forall w m a sig . (Carrier sig m, Effect sig, Monoid w) => Eff (WriterC w m) a -> m (w, a)
+runWriter :: forall w sig m a . (Carrier sig m, Effect sig, Monoid w) => Eff (WriterC w m) a -> m (w, a)
 runWriter m = runWriterC (interpret m) mempty
 {-# INLINE runWriter #-}
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
 --
 --   prop> run (execWriter (tell (Sum a) *> pure b)) == Sum a
-execWriter :: forall w m a sig . (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m w
+execWriter :: forall w sig m a . (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m w
 execWriter = fmap fst . runWriter
 {-# INLINE execWriter #-}
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Writer
 ( Writer(..)
 , tell
@@ -34,14 +34,14 @@ tell w = send (Tell w (ret ()))
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log alongside the result value.
 --
 --   prop> run (runWriter (tell (Sum a) *> pure b)) == (Sum a, b)
-runWriter :: (Carrier sig m, Effect sig, Monoid w) => Eff (WriterC w m) a -> m (w, a)
+runWriter :: forall w m a sig . (Carrier sig m, Effect sig, Monoid w) => Eff (WriterC w m) a -> m (w, a)
 runWriter m = runWriterC (interpret m) mempty
 {-# INLINE runWriter #-}
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
 --
 --   prop> run (execWriter (tell (Sum a) *> pure b)) == Sum a
-execWriter :: (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m w
+execWriter :: forall w m a sig . (Carrier sig m, Effect sig, Functor m, Monoid w) => Eff (WriterC w m) a -> m w
 execWriter = fmap fst . runWriter
 {-# INLINE execWriter #-}
 


### PR DESCRIPTION
As per discussion with @robrix, the parameters go in
statetype-signature-monad-returntype order.

This is a backwards-incompatible change, so we'll need to bump to
v0.2.0.0 next release. I've indicated this in the changelog.

Fixes #88.