### PR TITLE
Add Control.Effect.Resource.bracketOnError.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 - Provides explicit type parameters to `run`-style functions in `State`, `Reader`, and `Writer`. 
   This is a backwards-incompatible change for clients using these functions in combination
   with visible type applications.
+- Adds `bracketOnError` to `Resource`.
 
 # 0.1.2.1
 


### PR DESCRIPTION
I found myself needing this function in client code, and it can't be
reliably emulated downstream (unless we had a Mask effect), so the
simplest and most useful thing to do is to add another constructor to
the Resource effect.