### PR TITLE
Add a general `sendM` combinator.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 - Fixes a space leak with `WriterC`.
 - Removes the `Functor` constraint on `asks`.
 - Adds `bracketOnError` to `Resource`.
+- Adds `sendM` to `Lift`.
 
 # 0.1.2.1
 

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -1,17 +1,24 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts, MultiParamTypeClasses #-}
 module Control.Effect.Lift
 ( Lift(..)
+, lift
 , runM
 , LiftC(..)
 ) where
 
 import Control.Effect.Carrier
+import Control.Effect.Sum
 import Control.Effect.Internal
 import Control.Effect.Lift.Internal
 
 -- | Extract a 'Lift'ed 'Monad'ic action from an effectful computation.
 runM :: Monad m => Eff (LiftC m) a -> m a
 runM = runLiftC . interpret
+
+-- | Given a @Lift n@ constraint in a signature carried by @m@, use 'lift' to
+-- promote arbitrary actions of type @n a@ to @m a@.
+lift :: (Member (Lift n) sig, Carrier sig m, Functor n, Applicative m) => n a -> m a
+lift = send . Lift . fmap pure
 
 newtype LiftC m a = LiftC { runLiftC :: m a }
 

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, MultiParamTypeClasses #-}
 module Control.Effect.Lift
 ( Lift(..)
-, lift
+, sendM
 , runM
 , LiftC(..)
 ) where
@@ -15,10 +15,11 @@ import Control.Effect.Lift.Internal
 runM :: Monad m => Eff (LiftC m) a -> m a
 runM = runLiftC . interpret
 
--- | Given a @Lift n@ constraint in a signature carried by @m@, use 'lift' to
--- promote arbitrary actions of type @n a@ to @m a@.
-lift :: (Member (Lift n) sig, Carrier sig m, Functor n, Applicative m) => n a -> m a
-lift = send . Lift . fmap pure
+-- | Given a @Lift n@ constraint in a signature carried by @m@, 'sendM'
+-- promotes arbitrary actions of type @n a@ to @m a@. It is spiritually
+-- similar to @lift@ from the @MonadTrans@ typeclass.
+sendM :: (Member (Lift n) sig, Carrier sig m, Functor n, Applicative m) => n a -> m a
+sendM = send . Lift . fmap pure
 
 newtype LiftC m a = LiftC { runLiftC :: m a }
 


### PR DESCRIPTION
We could also call this `sendM` if we wanted to avoid a conflict with `mtl`, but given that the effect is called `Lift` I think this nomenclature is better.