### PR TITLE
Add explicit type variables to runError. (#100)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,10 @@
+- Provides explicit type parameters to `run`-style functions in `State`, `Reader`, `Writer`, and `Error`.
+  This is a backwards-incompatible change for clients using these functions in combination with visible type applications.
 - Adds benchmarks of `WriterC`/`VoidC` wrapped with `Eff` against their unwrapped counterparts.
 - Adds `Functor`, `Applicative`, and `Monad` instances for `WriterC`.
 - Adds `Functor`, `Applicative`, and `Monad` instances for `VoidC`.
 - Fixes a space leak with `WriterC`.
 - Removes the `Functor` constraint on `asks`.
-- Provides explicit type parameters to `run`-style functions in `State`, `Reader`, and `Writer`. 
-  This is a backwards-incompatible change for clients using these functions in combination
-  with visible type applications.
 
 # 0.1.2.1
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -46,7 +46,7 @@ catchError m h = send (Catch m h ret)
 -- | Run an 'Error' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.
 --
 --   prop> run (runError (pure a)) == Right @Int @Int a
-runError :: (Carrier sig m, Effect sig, Monad m) => Eff (ErrorC exc m) a -> m (Either exc a)
+runError :: forall exc sig m a . (Carrier sig m, Effect sig, Monad m) => Eff (ErrorC exc m) a -> m (Either exc a)
 runError = runErrorC . interpret
 
 newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }


### PR DESCRIPTION
As per discussion with @robrix, the exception type should come first
in the list of type parameters.