### PR TITLE
Add `finally` and `onException` resource effects.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 - Adds `Functor`, `Applicative`, and `Monad` instances for `VoidC`.
 - Fixes a space leak with `WriterC`.
 - Removes the `Functor` constraint on `asks`.
-- Adds `bracketOnError` to `Resource`.
+- Adds `bracketOnError`, `finally`, and `onException` to `Resource`.
 
 # 0.1.2.1
 


### PR DESCRIPTION
Because a generalized unlifting function is not possible with this
formulation of effects, it falls on us to provide APIs corresponding
to the remaining resource-management functions in `base`. This adds
`finally` and `onException` to `Control.Effect.Resource`, defined in
terms of `bracket` and `bracketOnError` respectively. This brings
`Resource` up to par with the resource-management functions provided
by `Control.Exception`.