### PR TITLE
Looser gets constraints

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 - Adds `Functor`, `Applicative`, and `Monad` instances for `WriterC`.
 - Adds `Functor`, `Applicative`, and `Monad` instances for `VoidC`.
 - Fixes a space leak with `WriterC`.
-- Removes the `Functor` constraint on `asks`.
+- Removes the `Functor` constraint on `asks` and `gets`.
 - Adds `bracketOnError`, `finally`, and `onException` to `Resource`.
 - Adds `sendM` to `Lift`.
 

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -38,8 +38,8 @@ get = send (Get ret)
 -- | Project a function out of the current state value.
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) == applyFun f a
-gets :: (Member (State s) sig, Carrier sig m, Functor m) => (s -> a) -> m a
-gets f = fmap f get
+gets :: (Member (State s) sig, Carrier sig m) => (s -> a) -> m a
+gets f = send (Get (ret . f))
 
 -- | Replace the state value with a new value.
 --


### PR DESCRIPTION
This PR loosens the constraints on `gets` just like #87 did for `asks`.